### PR TITLE
Update .cabal

### DIFF
--- a/hash-graph.cabal
+++ b/hash-graph.cabal
@@ -18,6 +18,10 @@ description:
   The <https://github.com/patrickdoc/hash-graph examples> directory contains
   many small demonstrations of how to use the library.
 
+source-repository head
+  type:     git
+  location: https://github.com/patrickdoc/hash-graph.git
+
 library
   exposed-modules:   Data.HashGraph.Strict
                      Data.HashGraph.Algorithms

--- a/hash-graph.cabal
+++ b/hash-graph.cabal
@@ -24,7 +24,7 @@ library
                      Data.HashGraph.Algorithms.MST
   -- other-modules:       
   -- other-extensions:    
-  build-depends:     base >=4.8 && <4.11
+  build-depends:     base >=4.8 && <4.12
                    , deepseq
                    , hashable
                    , heaps
@@ -37,7 +37,7 @@ test-suite tests
   type:              exitcode-stdio-1.0
   hs-source-dirs:    tests
   main-is:           Test.hs
-  build-depends:     base >=4.8 && <4.11
+  build-depends:     base >=4.8 && <4.12
                    , hash-graph
                    , hspec
                    , QuickCheck
@@ -49,7 +49,7 @@ benchmark benchmarks
   type:              exitcode-stdio-1.0
   hs-source-dirs:    benchmarks
   main-is:           Benchmark.hs
-  build-depends:     base >=4.8 && <4.11
+  build-depends:     base >=4.8 && <4.12
                    , criterion
                    , deepseq
                    , fgl


### PR DESCRIPTION
Allow new base (<4.12), everything build right (and tests passed).

I add a link to the git repo through the `source-repository` field as `HLint` or something else was complaining :)